### PR TITLE
Avoid inconsistent extra singleton dimensions in regularized OT cost evaluation

### DIFF
--- a/unbalancedot/entropy.py
+++ b/unbalancedot/entropy.py
@@ -170,7 +170,7 @@ class Entropy(object):
         return (
             scal(a, output_pot(f))
             + scal(b, output_pot(g))
-            + self.blur * a.sum(1)[:, None] * b.sum(1)[:, None]
+            + self.blur * a.sum(1) * b.sum(1)
         )
 
     def output_sinkhorn(self, a, x, b, y, cost, f_xy, f_xx, g_xy, g_yy):


### PR DESCRIPTION
When evaluating the cost function for regularized OT, avoid an inconsistent introduction of an extra singleton dimension, which lead to unwanted broadcasting behavior, and ultimately to returning a cost tensor of unexpected shape with redundant repeated elements.

If bs is the batch size, and N is the number of samples, consider the example below, illustrating what happens in the lines of code involved. There are three terms summed:
```
scal(a, output_pot(f))
+ scal(b, output_pot(g))
+ self.blur * a.sum(1)[:, None] * b.sum(1)[:, None]
```
- a, b, f, and g are all of shape (bs, N).
- The first two terms above are scalar products that evaluate to shape (bs,).
- For the final term, the respective sums of a and b over dimension 1 will evaluate to shape (bs,). Next, there is however an extra singleton dimension added, such that the element-wise product of the two has shape (bs, 1).
The main problem comes next. When tensors of shape (bs,) are summed with tensors of shape (bs, 1), the result will involve broadcasting, interpreting the (bs,) tensors to have shape (1, bs). The result of the summation will have shape (bs, bs).

The solution, in my opinion, is to simply drop the introduction of the extra singleton dimension, as follows:
```
scal(a, output_pot(f))
+ scal(b, output_pot(g))
+ self.blur * a.sum(1) * b.sum(1)
```
I believe this should be consistent with the other cost function evaluations as well (e.g. the output_sinkhorn method).